### PR TITLE
[2/4] Opt: wifi: Allow configuration of country code for wifi

### DIFF
--- a/service/java/com/android/server/wifi/WifiServiceImpl.java
+++ b/service/java/com/android/server/wifi/WifiServiceImpl.java
@@ -1084,6 +1084,14 @@ public final class WifiServiceImpl extends IWifiManager.Stub {
     }
 
     /**
+     * Get the operational country code
+     */
+    public String getCountryCode() {
+        enforceAccessPermission();
+        return mWifiStateMachine.getCountryCode();
+    }
+
+    /**
      * Set the operational frequency band
      * @param band One of
      *     {@link WifiManager#WIFI_FREQUENCY_BAND_AUTO},

--- a/service/java/com/android/server/wifi/WifiStateMachine.java
+++ b/service/java/com/android/server/wifi/WifiStateMachine.java
@@ -395,6 +395,9 @@ public class WifiStateMachine extends StateMachine {
     /* Tracks current frequency mode */
     private AtomicInteger mFrequencyBand = new AtomicInteger(WifiManager.WIFI_FREQUENCY_BAND_AUTO);
 
+    /* Tracks current country code */
+    private String mCountryCode = "GB";
+
     /* Tracks if we are filtering Multicast v4 packets. Default is to filter. */
     private AtomicBoolean mFilteringMulticastV4Packets = new AtomicBoolean(true);
 
@@ -2334,6 +2337,13 @@ public class WifiStateMachine extends StateMachine {
         } else {
             sendMessage(CMD_SET_COUNTRY_CODE, countryCodeSequence, persist ? 1 : 0, countryCode);
         }
+    }
+
+    /**
+     * Returns the operational country code
+     */
+    public String getCountryCode() {
+        return mCountryCode;
     }
 
     /**
@@ -5485,7 +5495,8 @@ public class WifiStateMachine extends StateMachine {
                     if (mLastSetCountryCode == null
                             || country.equals(mLastSetCountryCode) == false) {
                         if (mWifiNative.setCountryCode(country)) {
-                            mLastSetCountryCode = country;
+                            log("WIFI_COUNTRY_CODE set to " + country);
+                            mLastSetCountryCode = mCountryCode = country;
                         } else {
                             loge("Failed to set country code " + country);
                         }
@@ -7037,10 +7048,11 @@ public class WifiStateMachine extends StateMachine {
                     mWifiConfigStore.
                                 setLastSelectedConfiguration(WifiConfiguration.INVALID_NETWORK_ID);
                     break;
-                case CMD_SET_COUNTRY_CODE:
+                // allow changing also in connected state
+                /*case CMD_SET_COUNTRY_CODE:
                     messageHandlingStatus = MESSAGE_HANDLING_STATUS_DEFERRED;
                     deferMessage(message);
-                    break;
+                    break;*/
                 case CMD_START_SCAN:
                     //if (DBG) {
                         loge("WifiStateMachine CMD_START_SCAN source " + message.arg1


### PR DESCRIPTION
This makes getCountryCode behave like getFrequencyBand
This allows Settings to get/set country code like
it can for frequency band.

Change-Id: Ie4a3555e7dc7da5fe406673bd071e6a507426252